### PR TITLE
Add `FieldAccessor` & `field_accessor!` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ types.
 ```rust
 use field_path::registry::FieldAccessorRegistry;
 use field_path::field;
-use field_path::accessor;
+use field_path::field_accessor;
 
 #[derive(Default)]
 struct Vec2<T> {
@@ -47,7 +47,7 @@ let mut registry = FieldAccessorRegistry::default();
 let field = field!(<Vec2<f32>>::x);
 
 // Register accessors.
-registry.register_typed(field, accessor!(<Vec2<f32>>::x));
+registry.register_field(field_accessor!(<Vec2<f32>>::x));
 
 // Access field generically.
 let mut v = Vec2::default();

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -42,12 +42,8 @@ use crate::accessor;
 /// *FOO_ACC.get_mut(&mut foo) = 999;
 /// assert_eq!(foo.value, 999);
 /// ```
-#[derive(Debug, Hash, Clone, Copy)]
-pub struct Accessor<S, T>
-where
-    S: 'static,
-    T: 'static,
-{
+#[derive(Debug)]
+pub struct Accessor<S, T> {
     ref_fn: fn(&S) -> &T,
     mut_fn: fn(&mut S) -> &mut T,
 }
@@ -72,13 +68,27 @@ impl<S, T> Accessor<S, T> {
     pub fn get_mut<'a>(&self, source: &'a mut S) -> &'a mut T {
         (self.mut_fn)(source)
     }
+}
 
+impl<S, T> Accessor<S, T>
+where
+    S: 'static,
+    T: 'static,
+{
     /// Erases the type by converting it into an [`UntypedAccessor`].
     #[inline]
     pub const fn untyped(&self) -> UntypedAccessor {
         UntypedAccessor::new(self.ref_fn, self.mut_fn)
     }
 }
+
+impl<S, T> Clone for Accessor<S, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S, T> Copy for Accessor<S, T> {}
 
 /// Creates an [`Accessor`] that ensures the fields being accessed are
 /// correct for both immutable and mutable reference.
@@ -175,7 +185,11 @@ impl UntypedAccessor {
 
     /// Attempt to re-interpret this accessor as a typed [`Accessor`],
     /// returning `None` if the [`TypeId`]s do not match.
-    pub fn typed<S, T>(self) -> Option<Accessor<S, T>> {
+    pub fn typed<S, T>(self) -> Option<Accessor<S, T>>
+    where
+        S: 'static,
+        T: 'static,
+    {
         if self.source_id == TypeId::of::<S>()
             && self.target_id == TypeId::of::<T>()
         {
@@ -189,14 +203,22 @@ impl UntypedAccessor {
     }
 }
 
-impl<S, T> From<Accessor<S, T>> for UntypedAccessor {
+impl<S, T> From<Accessor<S, T>> for UntypedAccessor
+where
+    S: 'static,
+    T: 'static,
+{
     #[inline]
     fn from(accessor: Accessor<S, T>) -> Self {
         accessor.untyped()
     }
 }
 
-impl<S, T> From<&Accessor<S, T>> for UntypedAccessor {
+impl<S, T> From<&Accessor<S, T>> for UntypedAccessor
+where
+    S: 'static,
+    T: 'static,
+{
     #[inline]
     fn from(accessor: &Accessor<S, T>) -> Self {
         accessor.untyped()

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -42,13 +42,18 @@ use crate::accessor;
 /// *FOO_ACC.get_mut(&mut foo) = 999;
 /// assert_eq!(foo.value, 999);
 /// ```
-#[derive(Debug, Clone, Copy)]
-pub struct Accessor<S: 'static, T: 'static> {
+#[derive(Debug, Hash, Clone, Copy)]
+pub struct Accessor<S, T>
+where
+    S: 'static,
+    T: 'static,
+{
     ref_fn: fn(&S) -> &T,
     mut_fn: fn(&mut S) -> &mut T,
 }
 
 impl<S, T> Accessor<S, T> {
+    #[inline]
     pub const fn new(
         ref_fn: fn(&S) -> &T,
         mut_fn: fn(&mut S) -> &mut T,
@@ -56,15 +61,18 @@ impl<S, T> Accessor<S, T> {
         Self { ref_fn, mut_fn }
     }
 
+    #[inline]
     pub fn get_ref<'a>(&self, source: &'a S) -> &'a T {
         (self.ref_fn)(source)
     }
 
+    #[inline]
     pub fn get_mut<'a>(&self, source: &'a mut S) -> &'a mut T {
         (self.mut_fn)(source)
     }
 
-    pub const fn untyped(self) -> UntypedAccessor {
+    #[inline]
+    pub const fn untyped(&self) -> UntypedAccessor {
         UntypedAccessor::new(self.ref_fn, self.mut_fn)
     }
 }
@@ -91,13 +99,17 @@ impl<S, T> Accessor<S, T> {
 macro_rules! accessor {
     (<$source:ty>) => {
         $crate::accessor::Accessor::new(
+            #[inline(always)]
             |s: &$source| s,
+            #[inline(always)]
             |s: &mut $source| s,
         )
     };
     (<$source:ty>$(::$field:tt)+) => {
         $crate::accessor::Accessor::new(
+            #[inline(always)]
             |s: &$source| &s$(.$field)+,
+            #[inline(always)]
             |s: &mut $source| &mut s$(.$field)+
         )
     };
@@ -118,10 +130,15 @@ pub struct UntypedAccessor {
 
 impl UntypedAccessor {
     /// Create a new type-erased accessor from a typed accessor pair.
-    pub const fn new<S: 'static, T: 'static>(
+    #[inline]
+    pub const fn new<S, T>(
         ref_fn: fn(&S) -> &T,
         mut_fn: fn(&mut S) -> &mut T,
-    ) -> Self {
+    ) -> Self
+    where
+        S: 'static,
+        T: 'static,
+    {
         Self {
             ref_fn: ref_fn as *const (),
             mut_fn: mut_fn as *const (),
@@ -170,7 +187,15 @@ impl UntypedAccessor {
 }
 
 impl<S, T> From<Accessor<S, T>> for UntypedAccessor {
+    #[inline]
     fn from(accessor: Accessor<S, T>) -> Self {
+        accessor.untyped()
+    }
+}
+
+impl<S, T> From<&Accessor<S, T>> for UntypedAccessor {
+    #[inline]
+    fn from(accessor: &Accessor<S, T>) -> Self {
         accessor.untyped()
     }
 }

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -61,16 +61,19 @@ impl<S, T> Accessor<S, T> {
         Self { ref_fn, mut_fn }
     }
 
+    /// Get an immutable reference to the target type.
     #[inline]
     pub fn get_ref<'a>(&self, source: &'a S) -> &'a T {
         (self.ref_fn)(source)
     }
 
+    /// Get a mutable reference to the target type.
     #[inline]
     pub fn get_mut<'a>(&self, source: &'a mut S) -> &'a mut T {
         (self.mut_fn)(source)
     }
 
+    /// Erases the type by converting it into an [`UntypedAccessor`].
     #[inline]
     pub const fn untyped(&self) -> UntypedAccessor {
         UntypedAccessor::new(self.ref_fn, self.mut_fn)

--- a/src/field.rs
+++ b/src/field.rs
@@ -84,7 +84,7 @@ where
     S: 'static,
     T: 'static,
 {
-    /// Converts into a [`UntypedField`] type.
+    /// Erases the type by converting it into an [`UntypedField`].
     #[inline]
     pub const fn untyped(&self) -> UntypedField {
         UntypedField::new::<S, T>(self.field_path)
@@ -124,6 +124,7 @@ impl<S, T> _FieldBuilder<S, T> {
         }
     }
 
+    /// Creates the [`Field`] struct.
     #[inline]
     pub const fn build(self) -> Field<S, T> {
         Field {
@@ -195,11 +196,17 @@ impl UntypedField {
         }
     }
 
+    /// Creates a placeholder.
+    ///
+    /// This does not represent any valid path.
     #[inline]
     pub const fn placeholder() -> Self {
         Self::placeholder_with_path("$")
     }
 
+    /// Creates a placeholder with a custom path.
+    ///
+    /// The path may be valid, but the types will be empty.
     #[inline]
     pub const fn placeholder_with_path(
         field_path: &'static str,

--- a/src/field.rs
+++ b/src/field.rs
@@ -47,7 +47,7 @@ use crate::field;
 ///
 /// assert_eq!(PLAYER_AGE.field_path(), "::age");
 /// ```
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Field<S, T> {
     /// The path of the target field in the source.
     ///
@@ -65,6 +65,7 @@ impl<S, T> Field<S, T> {
     /// Construct a new [`Field`] from a raw field path string.
     ///
     /// Prefer the [`field!`] macro for type safety!
+    #[inline]
     pub const fn new(field_path: &'static str) -> Self {
         Self {
             field_path,
@@ -84,6 +85,7 @@ where
     T: 'static,
 {
     /// Converts into a [`UntypedField`] type.
+    #[inline]
     pub const fn untyped(&self) -> UntypedField {
         UntypedField::new::<S, T>(self.field_path)
     }
@@ -92,6 +94,7 @@ where
 impl<S, T> Copy for Field<S, T> {}
 
 impl<S, T> Clone for Field<S, T> {
+    #[inline]
     fn clone(&self) -> Self {
         *self
     }
@@ -121,6 +124,7 @@ impl<S, T> _FieldBuilder<S, T> {
         }
     }
 
+    #[inline]
     pub const fn build(self) -> Field<S, T> {
         Field {
             field_path: self.field_path,
@@ -178,9 +182,12 @@ pub struct UntypedField {
 }
 
 impl UntypedField {
-    pub const fn new<S: 'static, T: 'static>(
-        field_path: &'static str,
-    ) -> Self {
+    #[inline]
+    pub const fn new<S, T>(field_path: &'static str) -> Self
+    where
+        S: 'static,
+        T: 'static,
+    {
         Self {
             source_id: TypeId::of::<S>(),
             target_id: TypeId::of::<T>(),
@@ -188,10 +195,12 @@ impl UntypedField {
         }
     }
 
+    #[inline]
     pub const fn placeholder() -> Self {
         Self::placeholder_with_path("$")
     }
 
+    #[inline]
     pub const fn placeholder_with_path(
         field_path: &'static str,
     ) -> Self {
@@ -199,25 +208,31 @@ impl UntypedField {
     }
 
     /// Get the [`TypeId`] of the source type.
+    #[inline]
     pub const fn source_id(&self) -> TypeId {
         self.source_id
     }
 
     /// Get the [`TypeId`] of the target type.
+    #[inline]
     pub const fn target_id(&self) -> TypeId {
         self.target_id
     }
 
     /// See [`Field::field_path`].
+    #[inline]
     pub const fn field_path(&self) -> &'static str {
         self.field_path
     }
 
     /// Attempt to re-interpret this accessor as a typed [`Field`],
     /// returning `None` if the [`TypeId`]s do not match.
-    pub fn typed<S: 'static, T: 'static>(
-        self,
-    ) -> Option<Field<S, T>> {
+    #[inline]
+    pub fn typed<S, T>(self) -> Option<Field<S, T>>
+    where
+        S: 'static,
+        T: 'static,
+    {
         if self.source_id == TypeId::of::<S>()
             && self.target_id == TypeId::of::<T>()
         {
@@ -228,7 +243,11 @@ impl UntypedField {
     }
 
     /// Converts into a typed [`Field<S, T>`] without type checks.
-    pub const fn typed_unchecked<S: 'static, T>(self) -> Field<S, T> {
+    #[inline]
+    pub const fn typed_unchecked<S, T>(self) -> Field<S, T>
+    where
+        S: 'static,
+    {
         Field::new(self.field_path)
     }
 }
@@ -238,6 +257,7 @@ where
     S: 'static,
     T: 'static,
 {
+    #[inline]
     fn from(field: Field<S, T>) -> Self {
         field.untyped()
     }
@@ -248,6 +268,7 @@ where
     S: 'static,
     T: 'static,
 {
+    #[inline]
     fn from(field: &Field<S, T>) -> Self {
         field.untyped()
     }

--- a/src/field.rs
+++ b/src/field.rs
@@ -9,6 +9,7 @@
 //! that need to store, compare, or retrieve fields dynamically.
 
 use core::any::TypeId;
+use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 
 // For docs.
@@ -47,7 +48,7 @@ use crate::field;
 ///
 /// assert_eq!(PLAYER_AGE.field_path(), "::age");
 /// ```
-#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug)]
 pub struct Field<S, T> {
     /// The path of the target field in the source.
     ///
@@ -91,7 +92,34 @@ where
     }
 }
 
-impl<S, T> Copy for Field<S, T> {}
+impl<S, T> Hash for Field<S, T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.field_path.hash(state);
+    }
+}
+
+impl<S, T> PartialEq for Field<S, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.field_path == other.field_path
+    }
+}
+
+impl<S, T> Eq for Field<S, T> {}
+
+impl<S, T> PartialOrd for Field<S, T> {
+    fn partial_cmp(
+        &self,
+        other: &Self,
+    ) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<S, T> Ord for Field<S, T> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.field_path.cmp(other.field_path)
+    }
+}
 
 impl<S, T> Clone for Field<S, T> {
     #[inline]
@@ -99,6 +127,8 @@ impl<S, T> Clone for Field<S, T> {
         *self
     }
 }
+
+impl<S, T> Copy for Field<S, T> {}
 
 /// Builder used internally by the [`field!`] macro to construct
 /// [`Field`]s.
@@ -251,10 +281,7 @@ impl UntypedField {
 
     /// Converts into a typed [`Field<S, T>`] without type checks.
     #[inline]
-    pub const fn typed_unchecked<S, T>(self) -> Field<S, T>
-    where
-        S: 'static,
-    {
+    pub const fn typed_unchecked<S, T>(self) -> Field<S, T> {
         Field::new(self.field_path)
     }
 }

--- a/src/field_accessor.rs
+++ b/src/field_accessor.rs
@@ -10,6 +10,10 @@ use core::hash::{Hash, Hasher};
 use crate::accessor::Accessor;
 use crate::field::Field;
 
+// For docs.
+#[expect(unused_imports)]
+use crate::field_accessor;
+
 /// A specialized container pairing a [`Field`] with its [`Accessor`].
 #[derive(Debug, Clone, Copy)]
 pub struct FieldAccessor<S, T> {
@@ -44,7 +48,7 @@ impl<S, T> Eq for FieldAccessor<S, T> {}
 // impl<S, T> for
 
 /// Creates a [`FieldAccessor`] that ensures both [`Field`] and
-/// [`Accessors`] are pointing to the same field path.
+/// [`Accessor`] are pointing to the same field path.
 ///
 /// ## Example
 ///

--- a/src/field_accessor.rs
+++ b/src/field_accessor.rs
@@ -1,6 +1,14 @@
+//! This module defines the [`FieldAccessor`] type, which pairs a
+//! [`Field`] (representing the static path name) with an
+//! [`Accessor`] (providing functional pointers for data access).
+//!
+//! Use the [`field_accessor!`] macro to ensure that the path name and
+//! the access logic are always synchronized to the same field.
+
 use crate::accessor::Accessor;
 use crate::field::Field;
 
+/// A specialized container pairing a [`Field`] with its [`Accessor`].
 pub struct FieldAccessor<S, T>
 where
     S: 'static,
@@ -15,6 +23,7 @@ where
     S: 'static,
     T: 'static,
 {
+    #[inline]
     pub const fn new(
         field: Field<S, T>,
         accessor: Accessor<S, T>,
@@ -35,6 +44,7 @@ where
 /// struct Foo { value: i32 }
 ///
 /// const FOO_FIELD_ACC: FieldAccessor<Foo, i32> = field_accessor!(<Foo>::value);
+///
 /// assert_eq!(FOO_FIELD_ACC.field.field_path(), "::value");
 ///
 /// let mut foo = Foo { value: 42 };

--- a/src/field_accessor.rs
+++ b/src/field_accessor.rs
@@ -5,24 +5,19 @@
 //! Use the [`field_accessor!`] macro to ensure that the path name and
 //! the access logic are always synchronized to the same field.
 
+use core::hash::{Hash, Hasher};
+
 use crate::accessor::Accessor;
 use crate::field::Field;
 
 /// A specialized container pairing a [`Field`] with its [`Accessor`].
-pub struct FieldAccessor<S, T>
-where
-    S: 'static,
-    T: 'static,
-{
+#[derive(Debug, Clone, Copy)]
+pub struct FieldAccessor<S, T> {
     pub field: Field<S, T>,
     pub accessor: Accessor<S, T>,
 }
 
-impl<S, T> FieldAccessor<S, T>
-where
-    S: 'static,
-    T: 'static,
-{
+impl<S, T> FieldAccessor<S, T> {
     #[inline]
     pub const fn new(
         field: Field<S, T>,
@@ -31,6 +26,22 @@ where
         Self { field, accessor }
     }
 }
+
+impl<S, T> Hash for FieldAccessor<S, T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.field.hash(state);
+    }
+}
+
+impl<S, T> PartialEq for FieldAccessor<S, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.field.eq(&other.field)
+    }
+}
+
+impl<S, T> Eq for FieldAccessor<S, T> {}
+
+// impl<S, T> for
 
 /// Creates a [`FieldAccessor`] that ensures both [`Field`] and
 /// [`Accessors`] are pointing to the same field path.

--- a/src/field_accessor.rs
+++ b/src/field_accessor.rs
@@ -1,0 +1,54 @@
+use crate::accessor::Accessor;
+use crate::field::Field;
+
+pub struct FieldAccessor<S, T>
+where
+    S: 'static,
+    T: 'static,
+{
+    pub field: Field<S, T>,
+    pub accessor: Accessor<S, T>,
+}
+
+impl<S, T> FieldAccessor<S, T>
+where
+    S: 'static,
+    T: 'static,
+{
+    pub const fn new(
+        field: Field<S, T>,
+        accessor: Accessor<S, T>,
+    ) -> Self {
+        Self { field, accessor }
+    }
+}
+
+/// Creates a [`FieldAccessor`] that ensures both [`Field`] and
+/// [`Accessors`] are pointing to the same field path.
+///
+/// ## Example
+///
+/// ```
+/// use field_path::field_accessor;
+/// use field_path::field_accessor::FieldAccessor;
+///
+/// struct Foo { value: i32 }
+///
+/// const FOO_FIELD_ACC: FieldAccessor<Foo, i32> = field_accessor!(<Foo>::value);
+/// assert_eq!(FOO_FIELD_ACC.field.field_path(), "::value");
+///
+/// let mut foo = Foo { value: 42 };
+///
+/// assert_eq!(FOO_FIELD_ACC.accessor.get_ref(&foo), &42);
+/// *FOO_FIELD_ACC.accessor.get_mut(&mut foo) = 999;
+/// assert_eq!(foo.value, 999);
+/// ```
+#[macro_export]
+macro_rules! field_accessor {
+    (<$source:ty>$(::$field:tt)*) => {
+        $crate::field_accessor::FieldAccessor::new(
+            $crate::field!(<$source>$(::$field)*),
+            $crate::accessor!(<$source>$(::$field)*),
+        )
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@
 
 pub mod accessor;
 pub mod field;
+pub mod field_accessor;
 #[cfg(feature = "registry")]
 pub mod registry;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -11,18 +11,18 @@ use core::hash::Hash;
 use hashbrown::HashMap;
 
 use crate::accessor::{Accessor, UntypedAccessor};
-use crate::field::{Field, UntypedField};
+use crate::field::UntypedField;
+use crate::field_accessor::FieldAccessor;
 
 /// An [`AccessorRegistry`] using [`UntypedField`] as the key type.
 pub type FieldAccessorRegistry = AccessorRegistry<UntypedField>;
 
 impl FieldAccessorRegistry {
-    /// Registers a [`Field`] and [`Accessor`] pair in a type-safe
-    /// manner.
-    pub fn register_typed<S, T>(
+    /// Registers a [`FieldAccessor`] pair in a type-safe manner.
+    #[inline]
+    pub fn register_field<S, T>(
         &mut self,
-        field: Field<S, T>,
-        accessor: Accessor<S, T>,
+        FieldAccessor { field, accessor }: FieldAccessor<S, T>,
     ) {
         self.register(field.untyped(), accessor);
     }
@@ -57,6 +57,7 @@ pub struct AccessorRegistry<K> {
 
 impl<K> AccessorRegistry<K> {
     /// Construct an empty [`AccessorRegistry`].
+    #[inline]
     pub fn new() -> Self {
         Self {
             accessors: HashMap::new(),
@@ -68,6 +69,7 @@ impl<K: Eq + Hash> AccessorRegistry<K> {
     /// Registers an [`UntypedAccessor`] for a given key.
     ///
     /// Will overwrite existing accessor.
+    #[inline]
     pub fn register(
         &mut self,
         key: K,
@@ -80,10 +82,14 @@ impl<K: Eq + Hash> AccessorRegistry<K> {
     ///
     /// Returns an [`AccessorRegErr`] if the key does not exist or
     /// if the types do not match.
-    pub fn get<S: 'static, T: 'static>(
+    pub fn get<S, T>(
         &self,
         key: &K,
-    ) -> Result<Accessor<S, T>, AccessorRegErr> {
+    ) -> Result<Accessor<S, T>, AccessorRegErr>
+    where
+        S: 'static,
+        T: 'static,
+    {
         self.accessors
             .get(key)
             .ok_or(AccessorRegErr::KeyNotFound)?
@@ -93,6 +99,7 @@ impl<K: Eq + Hash> AccessorRegistry<K> {
 }
 
 impl<K> Default for AccessorRegistry<K> {
+    #[inline]
     fn default() -> Self {
         Self {
             accessors: HashMap::new(),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -23,7 +23,10 @@ impl FieldAccessorRegistry {
     pub fn register_field<S, T>(
         &mut self,
         FieldAccessor { field, accessor }: FieldAccessor<S, T>,
-    ) {
+    ) where
+        S: 'static,
+        T: 'static,
+    {
         self.register(field.untyped(), accessor);
     }
 }


### PR DESCRIPTION
- lifts the `'static` lifetime restriction on `Accessor`
- use `FieldAccessor` in `FieldAccessorRegistry`
- manual implementation of `Copy`, `Clone`, `Eq`, `PartialEq`, `Ord`, `PartialOrd`, `Hash` to prevent "type scoped" trait implementations