### PR TITLE
Make `Field: Send + Sync` regardless of `(S, T)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "field_path"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "field_path"
 description = "Type-safe, no-std field access and reflection utilities."
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/voxell-tech/field_path"

--- a/src/field.rs
+++ b/src/field.rs
@@ -55,7 +55,7 @@ pub struct Field<S, T> {
     /// Example: `Transform::translation::x` will have a field path
     /// of `"::translation::x"`.
     field_path: &'static str,
-    _marker: PhantomData<(S, T)>,
+    _marker: PhantomData<fn() -> (S, T)>,
 }
 
 impl<S, T> Field<S, T> {


### PR DESCRIPTION
Refer to: https://doc.rust-lang.org/reference/subtyping.html

(Thanks @MickHarrigan & @hankjordan for introducing this to me!)