### PR TITLE
Make `UntypedAccessor: Send + Sync`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "field_path"
-version = "0.4.0"
+version = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "field_path"
 description = "Type-safe, no-std field access and reflection utilities."
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/voxell-tech/field_path"

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -10,6 +10,10 @@
 
 use core::any::TypeId;
 
+use func_pointers::{MutFn, MutFnPtr, RefFn, RefFnPtr};
+
+pub mod func_pointers;
+
 // For docs.
 #[expect(unused_imports)]
 use crate::accessor;
@@ -44,8 +48,8 @@ use crate::accessor;
 /// ```
 #[derive(Debug)]
 pub struct Accessor<S, T> {
-    ref_fn: fn(&S) -> &T,
-    mut_fn: fn(&mut S) -> &mut T,
+    ref_fn: RefFn<S, T>,
+    mut_fn: MutFn<S, T>,
 }
 
 impl<S, T> Accessor<S, T> {
@@ -128,12 +132,6 @@ macro_rules! accessor {
     };
 }
 
-#[derive(Debug, Clone, Copy)]
-struct FnPtr(*const ());
-
-unsafe impl Send for FnPtr {}
-unsafe impl Sync for FnPtr {}
-
 /// A type-erased version of [`Accessor`].
 ///
 /// Stores the raw function pointers along with [`TypeId`]s of both
@@ -141,8 +139,8 @@ unsafe impl Sync for FnPtr {}
 /// the original [`Accessor`].
 #[derive(Debug, Clone, Copy)]
 pub struct UntypedAccessor {
-    ref_fn: FnPtr,
-    mut_fn: FnPtr,
+    ref_fn: RefFnPtr,
+    mut_fn: MutFnPtr,
     source_id: TypeId,
     target_id: TypeId,
 }
@@ -159,8 +157,8 @@ impl UntypedAccessor {
         T: 'static,
     {
         Self {
-            ref_fn: FnPtr(ref_fn as *const ()),
-            mut_fn: FnPtr(mut_fn as *const ()),
+            ref_fn: RefFnPtr::new(ref_fn),
+            mut_fn: MutFnPtr::new(mut_fn),
             source_id: TypeId::of::<S>(),
             target_id: TypeId::of::<T>(),
         }
@@ -178,13 +176,8 @@ impl UntypedAccessor {
     ) -> Accessor<S, T> {
         unsafe {
             Accessor {
-                ref_fn: core::mem::transmute::<*const (), fn(&S) -> &T>(
-                    self.ref_fn.0,
-                ),
-                mut_fn: core::mem::transmute::<
-                    *const (),
-                    fn(&mut S) -> &mut T,
-                >(self.mut_fn.0),
+                ref_fn: self.ref_fn.typed_unchecked::<S, T>(),
+                mut_fn: self.mut_fn.typed_unchecked::<S, T>(),
             }
         }
     }

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -128,15 +128,21 @@ macro_rules! accessor {
     };
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FnPtr(*const ());
+
+unsafe impl Send for FnPtr {}
+unsafe impl Sync for FnPtr {}
+
 /// A type-erased version of [`Accessor`].
 ///
-/// Stores the raw function pointers as `*const ()` along with
-/// [`TypeId`]s of both source and target. This allows
-/// dynamically checking and restoring the original [`Accessor`].
+/// Stores the raw function pointers along with [`TypeId`]s of both
+/// source and target. This allows dynamically checking and restoring
+/// the original [`Accessor`].
 #[derive(Debug, Clone, Copy)]
 pub struct UntypedAccessor {
-    ref_fn: *const (),
-    mut_fn: *const (),
+    ref_fn: FnPtr,
+    mut_fn: FnPtr,
     source_id: TypeId,
     target_id: TypeId,
 }
@@ -153,8 +159,8 @@ impl UntypedAccessor {
         T: 'static,
     {
         Self {
-            ref_fn: ref_fn as *const (),
-            mut_fn: mut_fn as *const (),
+            ref_fn: FnPtr(ref_fn as *const ()),
+            mut_fn: FnPtr(mut_fn as *const ()),
             source_id: TypeId::of::<S>(),
             target_id: TypeId::of::<T>(),
         }
@@ -173,12 +179,12 @@ impl UntypedAccessor {
         unsafe {
             Accessor {
                 ref_fn: core::mem::transmute::<*const (), fn(&S) -> &T>(
-                    self.ref_fn,
+                    self.ref_fn.0,
                 ),
                 mut_fn: core::mem::transmute::<
                     *const (),
                     fn(&mut S) -> &mut T,
-                >(self.mut_fn),
+                >(self.mut_fn.0),
             }
         }
     }

--- a/src/accessor/func_pointers.rs
+++ b/src/accessor/func_pointers.rs
@@ -1,0 +1,109 @@
+/// A type-erased immutable field accessor function pointer.
+#[derive(Debug, Clone, Copy)]
+pub struct RefFnPtr(*const ());
+
+unsafe impl Send for RefFnPtr {}
+unsafe impl Sync for RefFnPtr {}
+
+impl RefFnPtr {
+    /// Creates a new erased type of [`RefFn<S, T>`].
+    pub const fn new<S, T>(f: RefFn<S, T>) -> Self {
+        Self(f as *const ())
+    }
+
+    /// Re-interprets this pointer as a typed [`RefFn`] without
+    /// checking type correctness.
+    ///
+    /// # Safety
+    ///
+    /// Undefined behavior if `S` and `T` do not match the types used
+    /// when constructing this pointer.
+    pub const unsafe fn typed_unchecked<S, T>(&self) -> RefFn<S, T> {
+        unsafe {
+            core::mem::transmute::<*const (), RefFn<S, T>>(self.0)
+        }
+    }
+}
+
+/// A type-erased mutable field accessor function pointer.
+#[derive(Debug, Clone, Copy)]
+pub struct MutFnPtr(*const ());
+
+unsafe impl Send for MutFnPtr {}
+unsafe impl Sync for MutFnPtr {}
+
+impl MutFnPtr {
+    /// Creates a new erased type of [`MutFn<S, T>`].
+    pub const fn new<S, T>(f: MutFn<S, T>) -> Self {
+        Self(f as *const ())
+    }
+
+    /// Re-interprets this pointer as a typed [`MutFn`] without
+    /// checking type correctness.
+    ///
+    /// # Safety
+    ///
+    /// Undefined behavior if `S` and `T` do not match the types used
+    /// when constructing this pointer.
+    pub const unsafe fn typed_unchecked<S, T>(&self) -> MutFn<S, T> {
+        unsafe {
+            core::mem::transmute::<*const (), MutFn<S, T>>(self.0)
+        }
+    }
+}
+
+/// Immutable field accessor function: `fn(&S) -> &T`.
+pub type RefFn<S, T> = fn(&S) -> &T;
+
+/// Mutable field accessor function: `fn(&mut S) -> &mut T`.
+pub type MutFn<S, T> = fn(&mut S) -> &mut T;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Foo {
+        x: i32,
+        y: f32,
+    }
+
+    fn foo_x_ref(s: &Foo) -> &i32 {
+        &s.x
+    }
+    fn foo_x_mut(s: &mut Foo) -> &mut i32 {
+        &mut s.x
+    }
+    fn foo_y_ref(s: &Foo) -> &f32 {
+        &s.y
+    }
+
+    #[test]
+    fn ref_fn_ptr_roundtrip() {
+        let ptr = RefFnPtr::new(foo_x_ref);
+        let f: RefFn<Foo, i32> = unsafe { ptr.typed_unchecked() };
+        let foo = Foo { x: 42, y: 1.5 };
+        assert_eq!(f(&foo), &42);
+    }
+
+    #[test]
+    fn mut_fn_ptr_roundtrip() {
+        let ptr = MutFnPtr::new(foo_x_mut);
+        let f: MutFn<Foo, i32> = unsafe { ptr.typed_unchecked() };
+        let mut foo = Foo { x: 0, y: 1.5 };
+        *f(&mut foo) = 99;
+        assert_eq!(foo.x, 99);
+    }
+
+    #[test]
+    fn ref_fn_ptr_preserves_identity() {
+        let ptr_x = RefFnPtr::new(foo_x_ref);
+        let ptr_y = RefFnPtr::new(foo_y_ref);
+        let foo = Foo { x: 7, y: 1.5 };
+
+        let fx: RefFn<Foo, i32> = unsafe { ptr_x.typed_unchecked() };
+        let fy: RefFn<Foo, f32> = unsafe { ptr_y.typed_unchecked() };
+
+        assert_eq!(fx(&foo), &7);
+        assert_eq!(fy(&foo), &1.5);
+    }
+}


### PR DESCRIPTION
Adds a new type that wraps around `*const ()` and ensure it's `Send + Sync`.